### PR TITLE
column width for multiselect

### DIFF
--- a/Resources/views/Column/multiselect.html.twig
+++ b/Resources/views/Column/multiselect.html.twig
@@ -5,6 +5,7 @@
     "sortable": false,
     "visible": true,
     "title": "<input type='checkbox' name='multiselect_checkall' class='multiselect_checkall' />",
+    "width": "{{ column.width }}",
 {% endblock %}
 
 {% block data %}


### PR DESCRIPTION
Multiselect column gets too wide on Macintosh systems. Force width to param.
